### PR TITLE
YouTube videos move below on mobile

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -188,7 +188,7 @@ function App() {
       
       <div className="result">
 
-        <div className="non-video-results">
+        <div className="endpoint-results">
           <div className="wiki-results">
           {result.map((result,i) => {
             const url = `https://en.wikipedia.org/?curid=${result.pageid}`; 
@@ -225,7 +225,7 @@ function App() {
           </div>
         </div>
 
-        <div className="video-results">
+        <div className="endpoint-results">
           <div className="video-container">
           {ytresult.map((ytresult,i) => {
             const url = `https://www.youtube.com/embed/${ytresult.id.videoId}`;

--- a/src/index.css
+++ b/src/index.css
@@ -57,27 +57,37 @@ h1{
   transform: translateY(-5px);
 }
 
-.non-video-results {
-  width:50%;
+/* .endpoint-results {
+  width: 50%;
   float: left;
   padding: 10px;
-}
+} */
 
-.video-results {
+/* .video-results {
   width:50%;
   height: 100%;
   float: right;
   padding: 10px;
-}
+} */
 
 .result{
-  width: 75%;
+  width: 90%;
   margin: auto;
   padding: 16px;
   margin-bottom: 16px;
   background-color: #fff;
   border-radius: 16px;
   transition: 0.4s;
+  display: flex;
+  flex-wrap: wrap;
+  /* flex-direction: row; */
+}
+
+@media (min-width: 500px) {
+  .result .endpoint-results{
+     width:50% !important;
+     flex-wrap: wrap;
+}
 }
 
 .result:hover{


### PR DESCRIPTION
YouTube videos were barely visible on mobile screens. They now move under the Google and Wikipedia results so that they are much more visible now.